### PR TITLE
test: add tests to index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ jobs:
 ```
 
 ## TODO
-- [ ] Compete unit tests and strive for 100% test coverage
-- [x] GitHub workflow to run unit tests
-- [x] Workflow to check dist is built
+- [ ] Release v1 of action
 - [ ] Workflow to run regresssion tests with compiled action
 - [ ] list action in marketplace
+- [ ] Improve index.js file
+  - Should it be simplified and wrapped in a try/catch?
+  - How can we get 100% test coverage on it?
 
 ## Notes
 - Commit Analyzer https://github.com/semantic-release/commit-analyzer#releaserules

--- a/src/github.js
+++ b/src/github.js
@@ -10,7 +10,7 @@ const getLatestTag = async (octokit, owner, repo) => {
     repo
   })
 
-  if (res.data.length >= 1) return res.data[0]
+  if (res?.data?.length >= 1) return res.data[0]
 }
 
 const compareCommits = async (octokit, owner, repo, base, head) => {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const run = async () => {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
   const sha = process.env.GITHUB_SHA
 
-  let latestTag = ''
+  let latestTag
   try {
     latestTag = await github.getLatestTag(octokit, owner, repo)
   } catch (err) {
@@ -27,11 +27,13 @@ const run = async () => {
   }
 
   // get commits from last tag and calculate version bump
-  const commits = await github.compareCommits(octokit, owner, repo, latestTag.commit.sha, sha)
+  const commits = await github.compareCommits(octokit, owner, repo, latestTag?.commit?.sha, sha)
   const bump = await utils.getVersionBump(commits, core.getInput('default-bump'))
 
   const incrementedVersion = semver.inc(latestTag.name, bump)
   utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
 }
 
-run()
+if (process.env.NODE_ENV !== 'test') run()
+
+module.exports = { run }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,71 @@
+/* eslint-env jest */
+const core = require('@actions/core')
+const github = require('./github')
+
+jest.mock('./github')
+jest.spyOn(core, 'getInput')
+jest.spyOn(core, 'setFailed')
+jest.spyOn(core, 'setOutput')
+
+const index = require('./index')
+
+describe('index', () => {
+  beforeEach(() => {
+    process.env.GITHUB_REPOSITORY = 'foo/bar'
+    process.env['INPUT_GITHUB-TOKEN'] = 'test-token'
+    process.env['INPUT_DEFAULT-BUMP'] = 'patch'
+    process.env.INPUT_PREFIX = 'v'
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should fail when unable to get latest tag', async () => {
+    github.getLatestTag.mockRejectedValueOnce(new Error('test error'))
+
+    await index.run()
+    expect(core.setFailed).toBeCalledTimes(1)
+  })
+
+  it('should output default version bump (0.0.1) if no previous tags', async () => {
+    github.getLatestTag.mockResolvedValueOnce()
+
+    await index.run()
+    expect(core.getInput).toHaveBeenNthCalledWith(2, 'default-bump')
+    expect(core.getInput).toHaveNthReturnedWith(2, 'patch')
+
+    expect(core.setOutput).toHaveBeenNthCalledWith(1, 'version', '0.0.1')
+    expect(core.setOutput).toHaveBeenNthCalledWith(2, 'version-with-prefix', 'v0.0.1')
+    expect(core.setOutput).toHaveBeenNthCalledWith(3, 'major', 0)
+    expect(core.setOutput).toHaveBeenNthCalledWith(4, 'major-with-prefix', 'v0')
+    expect(core.setOutput).toHaveBeenNthCalledWith(5, 'minor', 0)
+    expect(core.setOutput).toHaveBeenNthCalledWith(6, 'patch', 1)
+  })
+
+  it('should fail when latest tag is no valid semver', async () => {
+    github.getLatestTag.mockResolvedValueOnce('invalid-semver')
+
+    await index.run()
+    expect(core.setFailed).toBeCalledTimes(1)
+    expect(core.setFailed).toHaveBeenNthCalledWith(1, 'latest tag name is not valid semver: "invalid-semver"')
+  })
+
+  it('should output versions', async () => {
+    const latestTag = {
+      name: 'v1.2.3',
+      commit: { sha: '123456789' }
+    }
+    github.getLatestTag.mockResolvedValueOnce(latestTag)
+    github.compareCommits.mockResolvedValueOnce([])
+
+    await index.run()
+
+    expect(core.setOutput).toHaveBeenNthCalledWith(1, 'version', '1.2.4')
+    expect(core.setOutput).toHaveBeenNthCalledWith(2, 'version-with-prefix', 'v1.2.4')
+    expect(core.setOutput).toHaveBeenNthCalledWith(3, 'major', 1)
+    expect(core.setOutput).toHaveBeenNthCalledWith(4, 'major-with-prefix', 'v1')
+    expect(core.setOutput).toHaveBeenNthCalledWith(5, 'minor', 2)
+    expect(core.setOutput).toHaveBeenNthCalledWith(6, 'patch', 4)
+  })
+})


### PR DESCRIPTION
Adds new tests to the `index.js` file. Not quite 100% -- will follow up later to see what it takes to get there.

Other minor changes
- Remove done todo items in README
- Minor fix to github.js and index.js to prevent undefined properties error