### PR TITLE
feat: remove prefix input

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ Design Descisions
     # Default: minor
     default-bump: ''
 
-    # Version prefix
-    # Default: v
-    prefix: ''
-
     # Set the versioning mode to run (future use-case)
     # Default: default
     mode: ''
@@ -32,10 +28,10 @@ Design Descisions
 ## Outputs
 | Name | Description |
 |------|-------------|
-`version` | full semantic version number without prefix (`1.2.3`)
-`version-with-prefix` | version number with prefix (`v1.2.3`)
+`version` | full semantic version number (`1.2.3`)
+`version-with-prefix` | version number with `v` prefix (`v1.2.3`)
 `major` | major version number
-`major-with-prefix` | major version number with prefix (`v1`)
+`major-with-prefix` | major version number with `v` prefix (`v1`)
 `minor` | minor version number
 `patch` | patch version number
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,8 +1,8 @@
 name: Conventional Versioning
 description: GitHub Action that returns a sematic version based on Conventional Commits
 branding:
-  icon: cloud
-  color: orange
+  icon: tag
+  color: blue
 
 inputs:
   github-token:
@@ -13,10 +13,6 @@ inputs:
     description: Default version bump (major, minor, or patch)
     required: false
     default: patch
-  prefix:
-    description: Version prefix / string to prepend to version
-    required: false
-    default: v
   mode:
     description: Sets the version mode to run - future use-case
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -44192,17 +44192,16 @@ const semver = __nccwpck_require__(1383)
 const commit = __nccwpck_require__(156)
 
 /**
- * Output version spec
+ * Output version details
  * @param {string} version version number
- * @param {string} prefix version prefix
  */
-const setVersionOutputs = (version, prefix) => {
-  const output = semver.parse(`${prefix}${version}`)
+const setVersionOutputs = (version) => {
+  const output = semver.parse(version)
 
   core.setOutput('version', output.version)
-  core.setOutput('version-with-prefix', `${prefix}${output.version}`)
+  core.setOutput('version-with-prefix', `v${output.version}`)
   core.setOutput('major', output.major)
-  core.setOutput('major-with-prefix', `${prefix}${output.major}`)
+  core.setOutput('major-with-prefix', `v${output.major}`)
   core.setOutput('minor', output.minor)
   core.setOutput('patch', output.patch)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,17 +3,16 @@ const semver = require('semver')
 const commit = require('@semantic-release/commit-analyzer')
 
 /**
- * Output version spec
+ * Output version details
  * @param {string} version version number
- * @param {string} prefix version prefix
  */
-const setVersionOutputs = (version, prefix) => {
-  const output = semver.parse(`${prefix}${version}`)
+const setVersionOutputs = (version) => {
+  const output = semver.parse(version)
 
   core.setOutput('version', output.version)
-  core.setOutput('version-with-prefix', `${prefix}${output.version}`)
+  core.setOutput('version-with-prefix', `v${output.version}`)
   core.setOutput('major', output.major)
-  core.setOutput('major-with-prefix', `${prefix}${output.major}`)
+  core.setOutput('major-with-prefix', `v${output.major}`)
   core.setOutput('minor', output.minor)
   core.setOutput('patch', output.patch)
 }


### PR DESCRIPTION
This change removes the input `prefix` and chooses to default to always using `v` for a prefix. Any other prefix is not valid semver -- technically having a prefix of `v` is not either but the semver parser excepts it.

Fixes #1