### PR TITLE
chore: remove prefix references

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44162,7 +44162,7 @@ module.exports = async () => {
   // return a default version if no previous github tags
   if (!latestTag) {
     const incrementedVersion = semver.inc('0.0.0', core.getInput('default-bump'))
-    return utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
+    return utils.setVersionOutputs(incrementedVersion)
   }
 
   if (!semver.valid(latestTag.name)) {
@@ -44174,7 +44174,7 @@ module.exports = async () => {
   const bump = await utils.getVersionBump(commits, core.getInput('default-bump'))
 
   const incrementedVersion = semver.inc(latestTag.name, bump)
-  utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
+  utils.setVersionOutputs(incrementedVersion)
 }
 
 

--- a/src/run.js
+++ b/src/run.js
@@ -19,7 +19,7 @@ module.exports = async () => {
   // return a default version if no previous github tags
   if (!latestTag) {
     const incrementedVersion = semver.inc('0.0.0', core.getInput('default-bump'))
-    return utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
+    return utils.setVersionOutputs(incrementedVersion)
   }
 
   if (!semver.valid(latestTag.name)) {
@@ -31,5 +31,5 @@ module.exports = async () => {
   const bump = await utils.getVersionBump(commits, core.getInput('default-bump'))
 
   const incrementedVersion = semver.inc(latestTag.name, bump)
-  utils.setVersionOutputs(incrementedVersion, core.getInput('prefix'))
+  utils.setVersionOutputs(incrementedVersion)
 }

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -14,7 +14,6 @@ describe('index', () => {
     process.env.GITHUB_REPOSITORY = 'foo/bar'
     process.env['INPUT_GITHUB-TOKEN'] = 'test-token'
     process.env['INPUT_DEFAULT-BUMP'] = 'patch'
-    process.env.INPUT_PREFIX = 'v'
   })
 
   afterEach(() => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -15,7 +15,7 @@ describe('utils', () => {
 
   describe('setVersionOutputs()', () => {
     it('should set output for all values', () => {
-      utils.setVersionOutputs('2.3.4', 'v')
+      utils.setVersionOutputs('2.3.4')
       expect(core.setOutput).toHaveBeenNthCalledWith(1, 'version', '2.3.4')
       expect(core.setOutput).toHaveBeenNthCalledWith(2, 'version-with-prefix', 'v2.3.4')
       expect(core.setOutput).toHaveBeenNthCalledWith(3, 'major', 2)


### PR DESCRIPTION
This change removes the previous used `prefix` input references. The `prefix` is now always `v` -- see this issue for more context https://github.com/jveldboom/action-conventional-versioning/issues/6 