### PR TITLE
fix: improve error messaging for invalid semver tag

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44185,7 +44185,7 @@ module.exports = async () => {
   }
 
   if (!semver.valid(latestRelease.name)) {
-    return core.setFailed(`latest tag name is not valid semver: ${JSON.stringify(latestRelease)}`)
+    return core.setFailed(`latest tag name "${latestRelease.name}" is not valid semver. GitHub API response: ${JSON.stringify(latestRelease)}`)
   }
 
   // get commits from last tag and calculate version bump

--- a/src/run.js
+++ b/src/run.js
@@ -29,7 +29,7 @@ module.exports = async () => {
   }
 
   if (!semver.valid(latestRelease.name)) {
-    return core.setFailed(`latest tag name is not valid semver: ${JSON.stringify(latestRelease)}`)
+    return core.setFailed(`latest tag name "${latestRelease.name}" is not valid semver. GitHub API response: ${JSON.stringify(latestRelease)}`)
   }
 
   // get commits from last tag and calculate version bump

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -51,11 +51,11 @@ describe('run', () => {
   })
 
   it('should fail when latest tag is no valid semver', async () => {
-    github.getLatestRelease.mockResolvedValueOnce('invalid-semver')
+    github.getLatestRelease.mockResolvedValueOnce({ name: 'invalid-semver' })
 
     await run()
     expect(core.setFailed).toBeCalledTimes(1)
-    expect(core.setFailed).toHaveBeenNthCalledWith(1, 'latest tag name is not valid semver: "invalid-semver"')
+    expect(core.setFailed).toHaveBeenNthCalledWith(1, 'latest tag name "invalid-semver" is not valid semver. GitHub API response: {"name":"invalid-semver"}')
   })
 
   it('should output versions', async () => {


### PR DESCRIPTION
This change improves the error messaging when the git release tag is invalid semver.

```
# previous message
latest tag name is not valid semver: {...}


# update message
latest tag name "invalid-tag" is not valid semver. GitHub API response: {...}
```