### PR TITLE
chore: update action to use node 20

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: yarn install
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Get version
         id: version

--- a/action.yaml
+++ b/action.yaml
@@ -36,5 +36,5 @@ outputs:
     description: Patch version number
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
## Description
This change updates the action to run on Node 20. This also updates the GHA workflows to test and build using Node 20. 