### PR TITLE
feat: update to node 24

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: yarn install
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Get version
         id: version
         uses: ./
 
       - name: Check version outputs
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const assert = require('assert')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./
         id: version

--- a/action.yaml
+++ b/action.yaml
@@ -40,5 +40,5 @@ outputs:
     description: Patch version number
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/jveldboom/action-conventional-versioning/issues"
   },
   "homepage": "https://github.com/jveldboom/action-conventional-versioning#readme",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "dependencies": {
     "@actions/core": "^2.0.3",
     "@actions/github": "^7.0.0",


### PR DESCRIPTION
This change bumps the version of Node from 20 to 24 in the action runtime and GitHub Actions workflows.